### PR TITLE
update_normal_prob_assignment segfault

### DIFF
--- a/src/inverse_design/prob_assignment.cpp
+++ b/src/inverse_design/prob_assignment.cpp
@@ -276,13 +276,14 @@ update_normal_prob_assignment(Forward3DSolver *tmp_solver,
     else{
       // take max prob face
       Face max_prob_face;
-      double max_prob = 0.;
+      double max_prob = 0.0;
       for (Face f: faces){
-        if (tmp_bnd_builder.face_region_area[f] > max_prob){
+        if (tmp_bnd_builder.face_region_area[f] > max_prob || max_prob == 0){
           max_prob_face = f;
           max_prob = tmp_bnd_builder.face_region_area[f];
         }
       }
+      
       updated_assignment.push_back({tmp_solver->hullGeometry->faceNormal(max_prob_face), cluster_goal_prob});
     }
 


### PR DESCRIPTION
Updated `update_normal_prob_assignment` to default to the first face when finding the max probability face to prevent a segfault caused by no face being selected due to all faces in `tmp_bnd_builder.face_region_area` having near 0 probabilities. I ran into the crash with some spherical and dodecahedron meshes.